### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/mobile-engineering


### PR DESCRIPTION
Is this repo still in use? If so I'd like to add y'all as codeowners. Is it ok if I change the default branch to `main` ?